### PR TITLE
feat(ADR-113): per-finding evidence class (proven/judged/attested)

### DIFF
--- a/.specs/decisions/ADR-112-framework-floor-mirrors-registry.md
+++ b/.specs/decisions/ADR-112-framework-floor-mirrors-registry.md
@@ -1,0 +1,174 @@
+---
+kind: adr
+id: ADR-112
+title: ADR-112 — The framework floor mirrors the framework registry (BYOR floor-sync)
+status: withdrawn
+---
+
+<!-- path: .specs/decisions/ADR-112-framework-floor-mirrors-registry.md -->
+
+# ADR-112 — The framework floor mirrors the framework registry, and drift fails loud
+
+**Status:** Withdrawn — 2026-06-18. Superseded by the Scenario 1+4 scoping decision (commercial focus narrowed to CORE self-governance + GRC gap-analysis). The BYOR onboard / starter-floor work this ADR addressed (Scenario 2) is parked, so its drift problem no longer needs a decision. Recorded, not deleted, so the reasoning is reconciled-against rather than re-derived. See ADR-113 for the live evidence-class work.
+**Date:** 2026-06-18
+**Grounding paper:** `CORE-BYOR.md` (§3 the Repository floor; §8 ADR-075 framework/project split) — primary.
+**Builds on:** ADR-075 (framework/project namespace — the floor is framework-owned), ADR-108 (external adoption ships a minimal authored starter + machinery floor), ADR-111 (onboard delivers the authored starter; **D5 explicitly deferred floor-sync, which this ADR decides**), ADR-008 (impact_level is governed externally, not embedded in `src/`).
+**Operationalizes:** UR-01 (Universal Input Acceptance), UR-07 (no overclaiming) — the on-ramp must actually run for an adopter before any doc promises it.
+**Closes:** the gating defect behind #640 step 2 (T1 in `CORE-BYOR-Program-Backlog.md`). Unblocks T2 (newcomer docs).
+
+---
+
+## Context
+
+T1 of the BYOR backlog asked a single honest question: *does the delivered
+starter actually enforce in a consumer repo?* Reproducing the offline audit from
+inside `examples/starter-intent/` (a representative onboarded repo) answered **no**,
+for a reason deeper than the backlog's note ("loaded the rules but logged no
+enforcement mappings").
+
+**The real blocker is a bootstrap crash, not a mapping miss.** Every `core-admin`
+invocation builds the `ActionExecutor`, which calls `registry.apply_risk_config()`.
+That method **fail-closes**: it raises `ConstitutionalError` if *any* registered
+atomic action lacks an `impact_level` entry in the *active* repo's
+`action_risk.yaml` (`src/body/atomic/registry.py`, `apply_risk_config`). CORE's
+code registers all 46 of its atomic actions regardless of the consumer's rule set,
+because the consumer runs CORE's engine. The shipped starter floor declares only
+44 — missing exactly `assisted.apply_diff` and `assisted.validate_diff`, which
+**ADR-109 added to CORE's registry but never propagated to the starter floor.**
+Result: `core-admin` is dead at bootstrap inside any onboarded repo — the audit
+never runs.
+
+Two adjacent findings frame the decision:
+
+- **The "no enforcement mappings" symptom is a source-tree artifact, not a
+  consumer-real fault.** `.env` pins `REPO_PATH=/opt/dev/CORE` while `settings.MIND`
+  resolves CWD-relative (→ the starter), so the bootstrap's mapping loader reads
+  CORE's `.intent` while `IntentRepository` reads the starter's. Built in isolation,
+  `AuditorContext` loads the starter's four mappings correctly. A genuine
+  pip-installed consumer (no CORE `.env`) would not hit this — which also means
+  *true* consumer mode cannot be fully simulated from the source tree; that waits
+  on the wheel (ADR-108 D3 / #674).
+
+- **The drift-guard that ADR-111 called "load-bearing for adopters" is falsely
+  green.** `examples/starter-intent/verify.sh` reports `OK` *on the crash*: it only
+  checks exit≠0 (a crash qualifies) and greps for the substring `starter.symbol_ids`,
+  which appears in the *declared-only log line* — not in any finding. The guard
+  passes without the audit ever running.
+
+The underlying question the governor named: **must a minimal consumer floor
+enumerate risk for all 46 CORE-internal actions, and should any new CORE action
+silently brick every consumer until re-synced?** ADR-111 D5 left "keeping the
+framework floor in sync with CORE upgrades" as "a separate concern, out of scope
+here." T1 forces that concern. This ADR decides it.
+
+## Decision
+
+### D1 — The enforcement/config machinery floor is framework-owned and MUST mirror the framework's authority exactly
+
+Per ADR-075, `action_risk.yaml` and its siblings under `enforcement/config/` are
+`framework`-namespace artifacts: they ship with CORE and apply to *any* governed
+project. They are **not** adopter-authored law (`project::<external>`), and they are
+**not** a curated subset the adopter maintains. The shipped starter floor's
+framework-owned configs MUST be a faithful mirror of CORE's canonical
+`.intent/enforcement/config/`. Any divergence between the shipped floor and the
+running framework's registry is a **framework defect**, not an adopter concern.
+
+The corollary, stated plainly: because a consumer runs CORE's whole engine, the
+consumer's `action_risk.yaml` must classify *every* action that engine can
+register — including actions the consumer's own rules never invoke. That breadth is
+inherent to shipping the engine, not negotiable per adopter.
+
+### D2 — Single source of truth: the floor derives from CORE's canonical config, it is not hand-maintained in parallel
+
+`examples/starter-intent/.intent/enforcement/config/` is **derived from**
+`/.intent/enforcement/config/` (CORE's canonical floor), not independently authored.
+For `action_risk.yaml` specifically — a domain-neutral `action_id → risk_level`
+table — the derived form is a verbatim copy. The starter constitution
+(`rules/starter.json`, `constitution/CONSTITUTION.md`) remains separately authored
+per ADR-108/111; this ADR governs only the *framework-owned* floor, not the authored
+rules layer. `sync-to-demo.sh` already copies starter→demo; the missing direction —
+CORE-registry→starter-floor — is what D2 closes.
+
+### D3 — The fail-closed risk gate stays; relaxation is rejected
+
+`apply_risk_config`'s `ConstitutionalError` on an unclassified registered action is
+**correct and retained.** It enforces `atomic_actions.impact_level_must_be_governed`
+and `governance.no_governance_bypass` ("if a precondition cannot be evaluated,
+block"). Relaxing it to let actions execute with ungoverned risk would import this
+repo's *development* permissiveness into *runtime* governance — exactly the inversion
+CLAUDE.md forbids — and would weaken the guarantee in the very market (regulated GRC,
+`CORE-BYOR.md` §7) where fail-closed risk classification is the product. The fix is
+to make the shipped floor complete (D1/D2), never to make the gate tolerant.
+
+### D4 — A standing drift-guard enforces floor ⊇ registry, so drift fails loud in CORE's CI — not at an adopter's bootstrap
+
+A deterministic check asserts that the shipped starter floor's `action_risk.yaml`
+classifies every action in CORE's registry (`floor.action_ids ⊇ registry.action_ids`).
+It runs in CORE's own audit / CI so a newly-added atomic action that is not reflected
+in the floor fails CORE's build — the framework catches its own drift before it ships,
+rather than an adopter discovering it as an unexplained `core-admin` crash. This is
+the durable, enforced form of "add a sync step"; a manual step rots without a standing
+rule (the #124→ADR-021→#594 regression is the cautionary precedent).
+
+### D5 — The starter regression guard must prove the audit ran, not pass on a crash
+
+`examples/starter-intent/verify.sh` is corrected to assert positive enforcement:
+parse `--format=json`, require a genuine `starter.symbol_ids` **finding** (not a
+substring of a log line), and fail on a traceback or `EXIT_INTERNAL_ERROR` (64). A
+bootstrap crash must read as RED. The guard's job is to prove the starter *enforces*,
+which a crash-then-substring-match never did.
+
+### D6 — Scope, sequencing, and the deferred dependency
+
+- The immediate drift-resync (adding `assisted.apply_diff: moderate` and
+  `assisted.validate_diff: safe` to the starter floor, mirroring CORE per D2) is the
+  *first application* of D1–D2 and may proceed once this ADR is accepted. It is an
+  application of a decided principle, not a fresh decision.
+- This ADR governs the **source-tree** floor and CORE's CI guard. It does **not**
+  resolve the `.env`/`REPO_PATH` source-tree split (Context, finding 1) — that is a
+  source-tree artifact a real consumer never hits, and fully verifying true
+  pip-consumer mode still waits on ADR-108 D3 / #674. D4's guard protects the
+  *shipped* floor; the wheel-packaging path (#674) is where true-consumer
+  verification lands.
+
+## Consequences
+
+- **The on-ramp becomes honest.** An onboarded repo's `core-admin` boots, and the
+  delivered four-rule constitution actually enforces — T2 (newcomer docs) is unblocked
+  on a verified, not assumed, foundation (UR-07).
+- **Drift is structurally impossible to ship silently.** D2 removes the parallel
+  hand-maintained copy; D4 fails CORE's build the moment the floor falls behind the
+  registry. New atomic actions can no longer brick adopters by omission.
+- **The fail-closed posture is preserved** — CORE never executes an action whose risk
+  is ungoverned, in its own repo or an adopter's.
+- **The drift-guard is real, not decorative.** D5 closes the false-green that let a
+  total starter failure read as `OK`.
+- **One honesty boundary is restated, not crossed:** true pip-consumer enforcement is
+  still pending the wheel (#674); this ADR makes the *source-tree* starter trustworthy
+  and keeps CORE's CI honest about floor completeness.
+
+## Alternatives considered
+
+- **Relax `apply_risk_config` to tolerate missing entries (governor option b).**
+  Rejected — D3. It would let actions run with ungoverned risk, weakening a
+  constitutional invariant and importing dev-permissiveness into runtime.
+- **Add a manual CORE→starter sync step (governor option c).** Rejected as the
+  *primary* mechanism: a documented step without enforcement rots (memory of
+  closures-without-rules regressing). Adopted only in its enforced form — D4.
+- **Treat the floor as an adopter-curated subset.** Rejected — contradicts ADR-075
+  (the floor is framework-owned) and is unworkable: the adopter runs the whole engine
+  and so inherits the whole registry; a subset cannot satisfy the fail-closed gate.
+
+## References
+
+- `CORE-BYOR.md` — §3 (the Repository floor), §8 (ADR-075 framework/project split,
+  byor.py disposition); this is grounded work under that paper's §9.
+- ADR-075 — framework/project namespace split (the floor is `framework`-owned).
+- ADR-108 — external adoption ships a minimal authored starter + machinery floor
+  (D3 machinery-in-wheel, the deferred true-consumer dependency / #674).
+- ADR-111 — onboard delivers the authored starter; **D5 deferred floor-sync, decided here.**
+- ADR-008 — impact_level is governed in `action_risk.yaml`, not embedded in `src/`.
+- `src/body/atomic/registry.py` (`apply_risk_config`) — the fail-closed gate retained by D3.
+- `examples/starter-intent/.intent/enforcement/config/action_risk.yaml`,
+  `examples/starter-intent/verify.sh` — the artifacts D2/D5 correct.
+- `CORE-BYOR-Program-Backlog.md` — T1 (this ADR closes the gate), T2 (unblocked).

--- a/.specs/decisions/ADR-113-per-finding-evidence-class.md
+++ b/.specs/decisions/ADR-113-per-finding-evidence-class.md
@@ -1,0 +1,159 @@
+---
+kind: adr
+id: ADR-113
+title: ADR-113 — Per-finding evidence class (proven / judged / attested)
+status: accepted
+---
+
+<!-- path: .specs/decisions/ADR-113-per-finding-evidence-class.md -->
+
+# ADR-113 — Every finding declares how it was established: proven, judged, or attested
+
+**Status:** Accepted — governor-ratified 2026-06-18
+**Date:** 2026-06-18
+**Grounding paper:** `CORE-BYOR.md` — §9 grounding item 4 ("per-finding attestation as a first-class evidence-trail field"), §5 parameter 2 (deterministic skeleton vs. semantic satisfaction), §7 (the honesty guardrail) — primary.
+**Kindred (distinct) principle:** `CORE-Instrument-Attestation.md` — the honesty of the *instruments*; this ADR is the honesty of each *finding*. Same value (UR-07 defensibility), different surface; neither subsumes the other.
+**Operationalizes:** UR-07 (Defensibility is Non-Negotiable) — primary; UR-01 (governs any artifact type) — secondary.
+**Serves:** the GRC gap-analysis service (Scenario 4 — the commercial wedge) and CORE's own self-audit (Scenario 1). Independent of the parked BYOR onboard/floor work (ADR-112).
+
+---
+
+## Context
+
+The governor has scoped the program to two configurations: **CORE governing
+itself (Scenario 1)** and **GRC gap-analysis for a customer (Scenario 4)**, with
+Scenario 4 as the revenue priority. The first concrete slice of Scenario 4 is a
+gap report over a folder of a customer's documents against a handful of compliance
+requirements — built specifically to demonstrate the one advantage we can defend
+that no competitor leads with: **honest per-finding provenance.**
+
+Recon (2026-06-18) confirmed the engine is already domain-general and that most of
+the slice exists:
+
+- A new artifact type ("compliance document") is a data declaration, not code
+  (`.intent/artifact_types/`; `spec_markdown.yaml` already anticipates "compliance
+  docs, regulatory evidence").
+- Reading a document corpus already works — file selection is glob-driven from rule
+  scopes (`audit_context.get_files`), not code-locked to `.py`.
+- **Proven** verdicts already exist (the deterministic gates: ast/regex/glob/artifact/…).
+- **Judged** verdicts already exist (`llm_gate`).
+
+What does **not** exist is the thing that makes the report honest rather than just
+another verdict stream: a finding does not currently say *how it was established*.
+`AuditFinding` (`shared/models/audit_models.py`) carries `check_id`, `severity`,
+`message`, `context` — but nothing distinguishing "I mechanically proved this" from
+"an AI judged this" from "no automated method can settle this; a human must attest."
+Today that distinction is implicit in *which engine ran* and is lost by the time a
+finding reaches a report.
+
+In a regulated market that structurally distrusts black-box AI, that lost
+distinction *is* the product. This ADR makes it a first-class, derived,
+non-inflatable property of every finding.
+
+## Decision
+
+### D1 — Every finding carries a first-class `evidence_class`
+
+`AuditFinding` gains a required field `evidence_class ∈ {proven, judged, attested}`
+(a new `EvidenceClass` enum beside `AuditSeverity` in `shared/models/audit_models.py`):
+
+- **proven** — established by a deterministic method (file present/absent, pattern
+  match, date arithmetic, structural check). Reproducible; no judgment.
+- **judged** — established by an AI/semantic reading of content. Carries the model's
+  reasoning and the evidence passage; is *an opinion, labelled as one* — never a fact.
+- **attested** — *cannot* be established automatically. The finding states what a
+  human reviewer must decide; it becomes settled only when a human attests.
+
+### D2 — `evidence_class` is DERIVED from the producing engine, never hand-set
+
+The label is not authored per rule or per finding. Each engine declares how it
+establishes truth — a class-level `evidence_class` attribute on `BaseEngine`
+(`mind/logic/engines/base.py`) — and `rule_executor` stamps the finding from the
+engine that produced it, at the single construction point that already knows
+`rule.engine`. This mirrors the existing `_map_enforcement_to_severity` pure
+derivation. Deriving from engine identity (not a separate lookup table, not a
+hand-label) is what makes the label trustworthy: it cannot drift from the method
+that actually ran, and there is no seam where an author could inflate it.
+
+Engine declarations: the deterministic gates declare `proven`; `llm_gate` (and its
+stub) declare `judged`; the new attestation engine (D4) declares `attested`.
+
+### D3 — The honesty invariant: never report a weaker method as a stronger one
+
+A finding's `evidence_class` states how it was *actually* established. No code path
+may upgrade it — a `judged` finding may never surface as `proven`, an `attested`
+item may never be silently auto-resolved. This is the load-bearing rule; everything
+else is plumbing. Selling a `judged` result as `proven` would fail the Final
+Invariant in the exact market where defensibility is the whole value.
+
+**Fail-closed default.** If an engine does not declare an `evidence_class`, findings
+from it default to the **weakest** class (`attested` — "treat as unproven, needs a
+human"), never to `proven`. Absence of a claim is never read as the strongest claim.
+
+### D4 — `attested` is a first-class outcome, not a failure or an omission
+
+An engine that cannot settle a requirement returns an explicit "requires human
+attestation" result — carrying *what* the reviewer must decide — modelled on the
+`RefusalResult` precedent (a refusal is a first-class outcome, not a bare
+`ok=False`). Crucially, an un-checkable requirement is **surfaced, not skipped**:
+the gap report shows "this needs your reviewer," it never quietly drops the line.
+Silent omission is precisely the dishonesty this product is sold against.
+
+### D5 — `evidence_class` is orthogonal to `severity`; they are two fields, not one
+
+Provenance ("how was this established") and severity ("how much does the gap
+matter") are independent surfaces. A `proven` finding can be low-severity; an
+`attested` item can be the most material gap in the report. They are not encoded in
+one another — two surfaces, two fields.
+
+### D6 — Scope: a general engine/finding property, first exercised by GRC
+
+This applies to **all** audits, not only the GRC slice. CORE's own self-audit
+(Scenario 1) gains honest labels for free — its deterministic gates report `proven`,
+its `llm_gate` rules report `judged` — which is the "we govern ourselves the same
+way we govern you" credibility anchor made literal (the hinge from the design
+discussion: our engine labels its own findings by the same honesty rule). The GRC
+gap report is the first consumer to surface the column to a paying customer; the
+offline audit's text/JSON output gains the field.
+
+## Consequences
+
+- **The differentiating advantage becomes mechanical, not marketing.** The report
+  can say, per line, exactly what was proven vs. judged vs. handed to a human — and
+  the architecture makes lying about it impossible (D2/D3).
+- **The smallest honest slice is now buildable on existing infrastructure** — the
+  only new code is the `EvidenceClass` enum + field, the `BaseEngine` attribute and
+  its per-engine declarations, the single derivation line in `rule_executor`, and the
+  one attestation engine. Everything else (corpus reading, deterministic + semantic
+  checks, report emission) already exists.
+- **CORE's own audits get more honest immediately** — every existing finding gains a
+  truthful provenance label at no extra authoring cost.
+- **A new obligation on every future engine:** it must declare its `evidence_class`.
+  The fail-closed default (D3) makes forgetting safe (it degrades to `attested`,
+  never to a false `proven`), but the linter/test surface should flag an undeclared
+  engine so the omission is visible, not silent.
+
+## Alternatives considered
+
+- **Hand-label the class per rule or per finding.** Rejected — it is a drift and
+  dishonesty vector (an author could mark a `judged` rule `proven`), and a label you
+  can set by hand is a label you cannot trust. Derive from the method that ran (D2).
+- **A central engine→class lookup table.** Rejected in favour of each engine
+  declaring its own class — a central table drifts out of step with the engine set
+  (the enum-list-vs-dispatch-chain failure mode), and the engine is the rightful
+  authority on how it establishes truth.
+- **Skip requirements that can't be checked automatically.** Rejected — silent
+  omission is exactly the failure mode this product exists to beat. The un-checkable
+  ones must be the most *visible* lines in the report (D4).
+- **Encode provenance inside `severity`.** Rejected — they are orthogonal surfaces;
+  conflating them loses information both ways (D5).
+
+## References
+
+- `CORE-BYOR.md` — §9 item 4 (this ADR), §5 parameter 2, §7 (honesty guardrail).
+- `CORE-Instrument-Attestation.md` — the kindred instrument-honesty principle (distinct surface).
+- `CORE-USER-REQUIREMENTS.md` — UR-07 (defensibility), UR-01 (any artifact type).
+- `src/shared/models/audit_models.py` — `AuditFinding`, `AuditSeverity` (the attach point; new `EvidenceClass`).
+- `src/mind/logic/engines/base.py` — `BaseEngine`, `EngineResult` (the new `evidence_class` declaration).
+- `src/mind/governance/rule_executor.py` — `_map_enforcement_to_severity` (the derivation pattern this mirrors; single finding-construction point).
+- ADR-112 (parked) — the BYOR onboard/floor work this is independent of.

--- a/src/cli/commands/check/formatters.py
+++ b/src/cli/commands/check/formatters.py
@@ -16,11 +16,25 @@ from rich.panel import Panel
 from rich.table import Table
 
 from shared.logger import getLogger
-from shared.models import AuditFinding, AuditSeverity
+from shared.models import AuditFinding, AuditSeverity, EvidenceClass
 
 
 logger = getLogger(__name__)
 console = Console()
+
+
+# ADR-113: how a verdict was established, rendered for the gap report.
+_EVIDENCE_STYLES = {
+    EvidenceClass.PROVEN: "[green]proven[/green]",
+    EvidenceClass.JUDGED: "[yellow]judged[/yellow]",
+    EvidenceClass.ATTESTED: "[magenta]needs human[/magenta]",
+}
+
+
+# ID: 7b5e2a91-3c64-4d8f-9a1e-6f2b8c4d7e03
+def _evidence_label(evidence_class: EvidenceClass) -> str:
+    """Render a finding's evidence class (ADR-113) for the Rich tables."""
+    return _EVIDENCE_STYLES.get(evidence_class, str(evidence_class))
 
 
 # ID: b0dc9c82-dd40-4970-94e8-911fd3354930
@@ -32,6 +46,7 @@ def print_verbose_findings(findings: list[AuditFinding]) -> None:
         header_style="bold magenta",
     )
     table.add_column("Severity", style="cyan")
+    table.add_column("Evidence", style="green")  # ADR-113
     table.add_column("Check ID", style="magenta")
     table.add_column("Message", style="white", overflow="fold")
     table.add_column("File:Line", style="yellow")
@@ -46,6 +61,7 @@ def print_verbose_findings(findings: list[AuditFinding]) -> None:
             location += f":{finding.line_number}"
         table.add_row(
             severity_styles.get(finding.severity, str(finding.severity)),
+            _evidence_label(finding.evidence_class),
             finding.check_id,
             finding.message,
             location,
@@ -68,6 +84,7 @@ def print_summary_findings(findings: list[AuditFinding]) -> None:
         header_style="bold magenta",
     )
     table.add_column("Severity", style="cyan")
+    table.add_column("Evidence", style="green")  # ADR-113
     table.add_column("Check ID", style="magenta")
     table.add_column("Message", style="white", overflow="fold")
     table.add_column("Occurrences", style="yellow", justify="right")
@@ -85,6 +102,7 @@ def print_summary_findings(findings: list[AuditFinding]) -> None:
         representative_message = finding_list[0].message
         table.add_row(
             severity_styles.get(severity, str(severity)),
+            _evidence_label(finding_list[0].evidence_class),
             check_id,
             representative_message,
             str(len(finding_list)),

--- a/src/mind/governance/rule_executor.py
+++ b/src/mind/governance/rule_executor.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from mind.logic.engines.base import extract_line_number, normalize_violation
 from shared.logger import getLogger
-from shared.models import AuditFinding, AuditSeverity
+from shared.models import AuditFinding, AuditSeverity, EvidenceClass
 
 
 # #306/#307: marker the llm_gate engine emits when an LLM call fails for
@@ -115,6 +115,13 @@ async def execute_rule(
             )
         ]
 
+    # ADR-113: the producing engine is the authority on how it establishes a
+    # verdict. Stamp its declared class onto every genuine-verdict finding
+    # below. Crash / unknown findings are NOT stamped — they keep the
+    # AuditFinding default (ATTESTED = "needs a human"), which is the honest
+    # label for a verdict we could not actually reach (D3 fail-closed).
+    engine_evidence_class = getattr(engine, "evidence_class", EvidenceClass.ATTESTED)
+
     if rule.is_context_level:
         # ADR-279 / #279: --files scopes per-file checks; context-level
         # rules look at the whole repo and can't be meaningfully filtered
@@ -137,6 +144,7 @@ async def execute_rule(
             )
             for f in engine_findings:
                 f.severity = severity
+                f.evidence_class = engine_evidence_class  # ADR-113
                 # Restore check_id == rule.rule_id invariant (#485). The per-file
                 # path at the bottom of this function constructs AuditFinding with
                 # check_id=rule.rule_id; the context-level path historically passed
@@ -237,6 +245,7 @@ async def execute_rule(
                             file_path=str(file_path.relative_to(context.repo_path)),
                             line_number=line_number,
                             context=details,
+                            evidence_class=engine_evidence_class,  # ADR-113
                         )
                     )
         except Exception as e:

--- a/src/mind/logic/engines/action_gate.py
+++ b/src/mind/logic/engines/action_gate.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 # ID: 480ac80d-4928-4408-ad9b-f4d77f1b3b25
@@ -24,6 +24,7 @@ class ActionGateEngine(BaseEngine):
     """
 
     engine_id = "action_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     # ID: cc81843f-33db-479a-9c5c-52d90e14134f
     async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:

--- a/src/mind/logic/engines/artifact_gate.py
+++ b/src/mind/logic/engines/artifact_gate.py
@@ -54,7 +54,7 @@ from shared.infrastructure.intent.vocabulary_projection import (
 from shared.logger import getLogger
 from shared.models import AuditFinding, AuditSeverity
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 if TYPE_CHECKING:
@@ -935,6 +935,7 @@ class ArtifactGateEngine(BaseEngine):
     """
 
     engine_id = "artifact_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: 3c7b9d12-58a4-4e6f-8c1d-2a9e6b4f3d70

--- a/src/mind/logic/engines/ast_gate/engine.py
+++ b/src/mind/logic/engines/ast_gate/engine.py
@@ -30,7 +30,7 @@ from mind.logic.engines.ast_gate.checks.protected_namespace_access_check import 
 from mind.logic.engines.ast_gate.checks.runtime_import_boundary import (
     RuntimeImportBoundaryCheck,
 )
-from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.base import BaseEngine, EngineResult, EvidenceClass
 from shared.infrastructure.intent.filesystem_operations import (
     FsOperationTaxonomy,
     load_filesystem_operations,
@@ -41,6 +41,7 @@ from shared.path_resolver import PathResolver
 # ID: 0b7d0813-a8e0-4901-b7fa-6c57b48c543d
 class ASTGateEngine(BaseEngine):
     engine_id = "ast_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     def __init__(self, path_resolver: PathResolver):
         self._paths = path_resolver

--- a/src/mind/logic/engines/attestation_gate.py
+++ b/src/mind/logic/engines/attestation_gate.py
@@ -1,0 +1,122 @@
+# src/mind/logic/engines/attestation_gate.py
+
+"""
+Attestation gate — the honest third outcome (ADR-113).
+
+Some requirements cannot be settled by any automated method: "controls are
+*appropriate* to the risk", "management has *reviewed* this". No deterministic
+gate and no AI judgment can honestly decide them. Rather than fake a verdict or
+silently drop the requirement, this engine emits a first-class
+"requires human attestation" finding that states exactly what a human reviewer
+must decide.
+
+This is the mechanism behind the `attested` evidence class: the engine declares
+`evidence_class = ATTESTED`, so `rule_executor` stamps every finding it produces
+as attested. The finding is SURFACED, never skipped (ADR-113 D4) — silent
+omission is precisely the dishonesty CORE's GRC gap-analysis is sold against.
+
+The engine is context-level: an attestation requirement is about the corpus /
+the organization, not a single file, so it emits one finding per requirement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from shared.logger import getLogger
+from shared.models import AuditFinding, AuditSeverity
+
+from .base import BaseEngine, EngineResult, EvidenceClass
+
+
+if TYPE_CHECKING:
+    from mind.governance.audit_context import AuditorContext
+
+
+logger = getLogger(__name__)
+
+
+# ID: 32bc579f-6dcb-49cc-80a9-ec7dd3d98007
+class AttestationGateEngine(BaseEngine):
+    """Emits a 'requires human attestation' finding for irreducibly-human rules.
+
+    Params (from the rule mapping):
+        prompt: str — what the reviewer must decide / confirm. Required;
+            an attestation rule with no prompt cannot tell the human what to
+            attest to, so the engine emits a configuration finding instead.
+        reference: str | None — optional citation of the source clause the
+            attestation discharges (surfaced in the evidence trail).
+    """
+
+    engine_id = "attestation_gate"
+    evidence_class = EvidenceClass.ATTESTED  # ADR-113: cannot be settled automatically
+
+    @classmethod
+    # ID: 0651c611-3de6-4317-836b-0cc8f4479be7
+    def is_context_level_for(cls, check_type: str | None) -> bool:
+        """Always context-level: an attestation requirement is about the corpus,
+        not a per-file fact. Dispatched once per rule, not once per file."""
+        return True
+
+    # ID: f9fe367a-ed35-4dbf-a59d-f46b51c767ec
+    async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:
+        """Per-file path is a no-op — this engine only runs context-level.
+
+        Present to satisfy the BaseEngine contract; the rule extractor routes
+        attestation rules through ``verify_context`` (see ``is_context_level_for``).
+        """
+        return EngineResult(
+            ok=True,
+            message="attestation_gate is context-level; per-file verify is a no-op.",
+            violations=[],
+            engine_id=self.engine_id,
+        )
+
+    # ID: bce2b978-fae7-44dd-93f6-51bd70217b2c
+    async def verify_context(
+        self, context: AuditorContext, params: dict[str, Any]
+    ) -> list[AuditFinding]:
+        """Emit one finding stating what a human must attest to.
+
+        The finding is always emitted — an attestation requirement is unresolved
+        until a human signs it, so the gap report must show it (ADR-113 D4). The
+        ``evidence_class`` is stamped ATTESTED by ``rule_executor`` from this
+        engine's declared class; severity comes from the rule's enforcement.
+        """
+        prompt = params.get("prompt")
+        if not prompt:
+            # A misconfigured attestation rule (no prompt) is a config bug, not a
+            # silent pass: surface it so the omission is visible.
+            return [
+                AuditFinding(
+                    check_id=self.engine_id,
+                    severity=AuditSeverity.HIGH,
+                    message=(
+                        "attestation_gate rule is missing a 'prompt' param — "
+                        "cannot tell the reviewer what to attest to. Add "
+                        "params.prompt to the rule's enforcement mapping."
+                    ),
+                    file_path=None,
+                    context={
+                        "finding_type": "ATTESTATION_MISCONFIGURED",
+                        "engine_id": self.engine_id,
+                    },
+                )
+            ]
+
+        reference = params.get("reference")
+        return [
+            AuditFinding(
+                check_id=self.engine_id,
+                severity=AuditSeverity.MEDIUM,
+                message=f"HUMAN ATTESTATION REQUIRED — {prompt}",
+                file_path=None,
+                context={
+                    "finding_type": "REQUIRES_ATTESTATION",
+                    "engine_id": self.engine_id,
+                    "attestation_prompt": prompt,
+                    "reference": reference,
+                },
+            )
+        ]

--- a/src/mind/logic/engines/base.py
+++ b/src/mind/logic/engines/base.py
@@ -16,7 +16,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
+
+from shared.models.audit_models import EvidenceClass
 
 
 # Pattern for "Line N:" or "(line N)" embedded in engine violation messages —
@@ -126,6 +128,14 @@ class BaseEngine(ABC):
     Now natively async to support the Database-as-SSOT principle
     without violating loop-hijacking rules.
     """
+
+    # ADR-113: how this engine establishes a verdict. The engine is the
+    # authority on its own evidence class — the rule_executor stamps it onto
+    # every genuine-verdict finding the engine produces. Fail-closed default
+    # is ATTESTED ("needs a human"): an engine that forgets to declare its
+    # class degrades to the weakest, never to a false PROVEN (ADR-113 D3).
+    # Deterministic gates override to PROVEN; llm_gate to JUDGED.
+    evidence_class: ClassVar[EvidenceClass] = EvidenceClass.ATTESTED
 
     @abstractmethod
     # ID: db4c48d2-4ccc-4182-bb37-29973471b8bb

--- a/src/mind/logic/engines/cli_gate/engine.py
+++ b/src/mind/logic/engines/cli_gate/engine.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.base import BaseEngine, EngineResult, EvidenceClass
 from mind.logic.engines.cli_gate.base_check import CliCheck
 from mind.logic.engines.cli_gate.checks import (
     AsyncExecutionCheck,
@@ -62,6 +62,7 @@ class CliGateEngine(BaseEngine):
     """Context-level auditor for the Typer command registry."""
 
     engine_id = "cli_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: 060dc0c2-6d54-4544-aaec-86e1ef978243

--- a/src/mind/logic/engines/contracts_gate.py
+++ b/src/mind/logic/engines/contracts_gate.py
@@ -53,7 +53,7 @@ from sqlalchemy import text
 from shared.logger import getLogger
 from shared.models import AuditFinding, AuditSeverity
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 if TYPE_CHECKING:
@@ -136,6 +136,7 @@ class ContractsGateEngine(BaseEngine):
     """
 
     engine_id = _ENGINE_ID
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: effd788b-b7b5-4d1e-ab2a-24d8d829e2f7

--- a/src/mind/logic/engines/glob_gate.py
+++ b/src/mind/logic/engines/glob_gate.py
@@ -16,7 +16,7 @@ import fnmatch
 from pathlib import Path
 from typing import Any
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 # ID: 3af1be62-fd37-41f9-b842-8029e8fba49d
@@ -35,6 +35,7 @@ class GlobGateEngine(BaseEngine):
     """
 
     engine_id = "glob_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     # ID: 6576f3e8-c1f6-4180-bcd2-076f7cd7a491
     async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:

--- a/src/mind/logic/engines/knowledge_gate.py
+++ b/src/mind/logic/engines/knowledge_gate.py
@@ -25,7 +25,7 @@ from mind.logic.engines._knowledge_gate_duplication import (
     _check_semantic_duplication,
     _resolve_symbol_path,
 )
-from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.base import BaseEngine, EngineResult, EvidenceClass
 from shared.logger import getLogger
 from shared.models import AuditFinding, AuditSeverity
 
@@ -42,6 +42,7 @@ class KnowledgeGateEngine(BaseEngine):
     """
 
     engine_id = "knowledge_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: 9e3a7d51-6b2f-4c89-a04d-1e8b5c3f9a26

--- a/src/mind/logic/engines/llm_gate.py
+++ b/src/mind/logic/engines/llm_gate.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any
 from shared.ai.prompt_model import PromptModel
 from shared.logger import getLogger
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 if TYPE_CHECKING:
@@ -65,6 +65,7 @@ class LLMGateEngine(BaseEngine):
     """
 
     engine_id = "llm_gate"
+    evidence_class = EvidenceClass.JUDGED  # ADR-113: AI/semantic verdict
 
     def __init__(
         self,

--- a/src/mind/logic/engines/llm_gate_stub.py
+++ b/src/mind/logic/engines/llm_gate_stub.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.base import BaseEngine, EngineResult, EvidenceClass
 from shared.logger import getLogger
 
 
@@ -34,6 +34,7 @@ class LLMGateStubEngine(BaseEngine):
     # is only reachable through the explicit fallback path in
     # EngineRegistry.get() when no LLM client is wired.
     engine_id = "llm_gate_stub"
+    evidence_class = EvidenceClass.JUDGED  # ADR-113: stands in for the judged llm_gate
 
     def __init__(self):
         """Initialize stub engine - no LLM client needed."""

--- a/src/mind/logic/engines/regex_gate.py
+++ b/src/mind/logic/engines/regex_gate.py
@@ -16,7 +16,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 # ID: 76df2589-c0fd-48e3-b359-7c58e1c5ff71
@@ -27,6 +27,7 @@ class RegexGateEngine(BaseEngine):
     """
 
     engine_id = "regex_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     # ID: 53cc3e25-0d0c-41a7-8ad3-32f8e6963a1a
     async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:

--- a/src/mind/logic/engines/runtime_gate.py
+++ b/src/mind/logic/engines/runtime_gate.py
@@ -40,7 +40,7 @@ from sqlalchemy import text
 from shared.logger import getLogger
 from shared.models import AuditFinding, AuditSeverity
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 if TYPE_CHECKING:
@@ -78,6 +78,7 @@ class RuntimeGateEngine(BaseEngine):
     """
 
     engine_id = _ENGINE_ID
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: 1f2e3d4c-5b6a-7980-1234-5678abcdef01

--- a/src/mind/logic/engines/taxonomy_gate.py
+++ b/src/mind/logic/engines/taxonomy_gate.py
@@ -44,7 +44,7 @@ from shared.models import AuditFinding, AuditSeverity
 from shared.path_resolver import PathResolver
 from shared.processors.yaml_processor import strict_yaml_processor
 
-from .base import BaseEngine, EngineResult
+from .base import BaseEngine, EngineResult, EvidenceClass
 
 
 if TYPE_CHECKING:
@@ -99,6 +99,7 @@ class TaxonomyGateEngine(BaseEngine):
     """
 
     engine_id = "taxonomy_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: f3a8d672-5c19-4e2b-b481-6d9e7f3a2c14

--- a/src/mind/logic/engines/workflow_gate/engine.py
+++ b/src/mind/logic/engines/workflow_gate/engine.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.base import BaseEngine, EngineResult, EvidenceClass
 from mind.logic.engines.workflow_gate.base_check import (
     StructuredViolation,
     WorkflowCheck,
@@ -52,6 +52,7 @@ class WorkflowGateEngine(BaseEngine):
     """
 
     engine_id = "workflow_gate"
+    evidence_class = EvidenceClass.PROVEN  # ADR-113: deterministic verdict
 
     @classmethod
     # ID: 2b8e4f3d-1a9c-4b65-9d7e-3f8a1c5e2b04

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -5,7 +5,7 @@ Makes all Pydantic models in this directory available for easy import.
 
 from __future__ import annotations
 
-from .audit_models import AuditFinding, AuditSeverity
+from .audit_models import AuditFinding, AuditSeverity, EvidenceClass
 from .capability_models import CapabilityMeta
 from .drift_models import DriftReport
 from .embedding_payload import EmbeddingPayload
@@ -35,6 +35,7 @@ __all__ = [
     "DetailedPlanStep",
     "DriftReport",
     "EmbeddingPayload",
+    "EvidenceClass",
     "ExecutionResults",
     "ExecutionTask",
     "PhaseResult",

--- a/src/shared/models/audit_models.py
+++ b/src/shared/models/audit_models.py
@@ -6,8 +6,34 @@ Defines the Pydantic models for representing the results of a constitutional aud
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import IntEnum
+from enum import Enum, IntEnum
 from typing import Any
+
+
+# ID: 3f9b1d52-8a4e-4c17-b0d6-2e7f9a4c1b83
+class EvidenceClass(str, Enum):
+    """How a finding's verdict was established (ADR-113).
+
+    Orthogonal to ``AuditSeverity`` (how *bad* the gap is): this records how
+    the verdict was *reached*, which is the honesty surface CORE's GRC
+    gap-analysis is sold on. Stored as its lowercase string value.
+
+    - ``proven``   — established by a deterministic method (presence, pattern,
+      structure, date arithmetic). Reproducible; no judgment.
+    - ``judged``   — established by an AI/semantic reading. An opinion, labelled
+      as one — never a fact.
+    - ``attested`` — cannot be established automatically; a human must decide.
+      Also the fail-closed default: an undeclared engine, a crashed check, or a
+      muted check degrades to ``attested`` (never to a false ``proven``), per
+      ADR-113 D3. Absence of a claim is never read as the strongest claim.
+    """
+
+    PROVEN = "proven"
+    JUDGED = "judged"
+    ATTESTED = "attested"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 # ID: 5ccdae76-2214-413d-8551-13d4b224b694
@@ -56,6 +82,11 @@ class AuditFinding:
     file_path: str | None = None
     line_number: int | None = None
     context: dict[str, Any] = field(default_factory=dict)
+    # ADR-113: how this verdict was established. Fail-closed default is
+    # ATTESTED ("unknown / needs a human") — never a false PROVEN. The
+    # rule_executor overwrites this with the producing engine's declared
+    # class for genuine verdicts; crash/unknown findings keep the default.
+    evidence_class: EvidenceClass = EvidenceClass.ATTESTED
 
     def __init__(
         self,
@@ -67,12 +98,14 @@ class AuditFinding:
         context: dict[str, Any] | None = None,
         *,
         details: dict[str, Any] | None = None,
+        evidence_class: EvidenceClass = EvidenceClass.ATTESTED,
     ) -> None:
         self.check_id = check_id
         self.severity = severity
         self.message = message
         self.file_path = file_path
         self.line_number = line_number
+        self.evidence_class = evidence_class
 
         base_context: dict[str, Any] = dict(context or {})
         if details:
@@ -86,6 +119,7 @@ class AuditFinding:
         return {
             "check_id": self.check_id,
             "severity": str(self.severity),
+            "evidence_class": str(self.evidence_class),  # ADR-113
             "message": self.message,
             "file_path": self.file_path,
             "line_number": self.line_number,

--- a/tests/mind/governance/test_evidence_class__adr113.py
+++ b/tests/mind/governance/test_evidence_class__adr113.py
@@ -1,0 +1,235 @@
+"""ADR-113 — per-finding evidence class (proven / judged / attested).
+
+Proves the honesty mechanism CORE's GRC gap-analysis is sold on:
+
+- every engine declares how it establishes a verdict;
+- ``rule_executor`` stamps that declared class onto genuine-verdict findings;
+- a crash / unknown verdict degrades to ATTESTED (fail-closed), never a false
+  PROVEN (ADR-113 D3);
+- the attestation engine SURFACES "needs a human" — it never silently skips
+  an un-checkable requirement (ADR-113 D4).
+
+The derivation is exercised through the real ``execute_rule`` path against a
+light fake context — the same way the hosted GRC service drives the engine
+(call the engine directly; no CLI, no DB).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mind.governance.executable_rule import ExecutableRule
+from mind.governance.rule_executor import execute_rule
+from mind.logic.engines.ast_gate.engine import ASTGateEngine
+from mind.logic.engines.attestation_gate import AttestationGateEngine
+from mind.logic.engines.base import BaseEngine, EngineResult
+from mind.logic.engines.llm_gate import LLMGateEngine
+from mind.logic.engines.regex_gate import RegexGateEngine
+from shared.models import AuditFinding, AuditSeverity, EvidenceClass
+
+
+# --------------------------------------------------------------------------
+# Engine declarations — each engine is the authority on its own class (D2).
+# --------------------------------------------------------------------------
+
+
+def test_deterministic_engines_declare_proven() -> None:
+    assert RegexGateEngine.evidence_class is EvidenceClass.PROVEN
+    assert ASTGateEngine.evidence_class is EvidenceClass.PROVEN
+
+
+def test_llm_gate_declares_judged() -> None:
+    assert LLMGateEngine.evidence_class is EvidenceClass.JUDGED
+
+
+def test_attestation_gate_declares_attested() -> None:
+    assert AttestationGateEngine.evidence_class is EvidenceClass.ATTESTED
+
+
+def test_baseengine_default_is_failclosed_attested() -> None:
+    # An engine that forgets to declare its class degrades to the weakest,
+    # never to a false PROVEN (ADR-113 D3 fail-closed default).
+    assert BaseEngine.evidence_class is EvidenceClass.ATTESTED
+
+
+def test_auditfinding_default_evidence_class_is_attested() -> None:
+    f = AuditFinding(check_id="x", severity=AuditSeverity.INFO, message="m")
+    assert f.evidence_class is EvidenceClass.ATTESTED
+
+
+# --------------------------------------------------------------------------
+# Test doubles for the derivation path.
+# --------------------------------------------------------------------------
+
+
+class _FakeContext:
+    """Minimal stand-in for AuditorContext sufficient for execute_rule."""
+
+    def __init__(self, files: list[Path]) -> None:
+        self.repo_path = Path("/repo")
+        self._files = files
+        self.force_llm = False
+
+    def get_files(self, include: Any, exclude: Any = None) -> list[Path]:
+        return self._files
+
+
+class _ProvenEngine(BaseEngine):
+    engine_id = "fake_proven"
+    evidence_class = EvidenceClass.PROVEN
+
+    async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:
+        return EngineResult(False, "x", ["required record absent"], self.engine_id)
+
+
+class _JudgedEngine(BaseEngine):
+    engine_id = "fake_judged"
+    evidence_class = EvidenceClass.JUDGED
+
+    async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:
+        return EngineResult(False, "x", ["policy may not cover remote MFA"], self.engine_id)
+
+
+class _CrashEngine(BaseEngine):
+    # Declares PROVEN, but crashes mid-check: the verdict is genuinely unknown.
+    engine_id = "fake_crash"
+    evidence_class = EvidenceClass.PROVEN
+
+    async def verify(self, file_path: Path, params: dict[str, Any]) -> EngineResult:
+        raise RuntimeError("boom")
+
+
+def _patch_engine(monkeypatch: pytest.MonkeyPatch, engine: BaseEngine) -> None:
+    monkeypatch.setattr(
+        "mind.logic.engines.registry.EngineRegistry.get",
+        lambda engine_id: engine,
+    )
+
+
+# --------------------------------------------------------------------------
+# Derivation — execute_rule stamps the producing engine's class (D2/D3).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proven_verdict_is_labelled_proven(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_engine(monkeypatch, _ProvenEngine())
+    rule = ExecutableRule(
+        rule_id="grc.security_policy_exists",
+        engine="fake_proven",
+        params={},
+        enforcement="blocking",
+        scope=["**/*.md"],
+    )
+    findings = await execute_rule(rule, _FakeContext([Path("/repo/security-policy.md")]))
+    assert len(findings) == 1
+    assert findings[0].evidence_class is EvidenceClass.PROVEN
+
+
+@pytest.mark.asyncio
+async def test_judged_verdict_is_labelled_judged(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_engine(monkeypatch, _JudgedEngine())
+    rule = ExecutableRule(
+        rule_id="grc.requires_mfa_remote",
+        engine="fake_judged",
+        params={},
+        enforcement="reporting",
+        scope=["**/*.md"],
+    )
+    findings = await execute_rule(rule, _FakeContext([Path("/repo/access-policy.md")]))
+    assert len(findings) == 1
+    assert findings[0].evidence_class is EvidenceClass.JUDGED
+
+
+@pytest.mark.asyncio
+async def test_crash_degrades_to_attested_never_proven(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crashed PROVEN engine must NOT yield a 'proven' finding (D3)."""
+    _patch_engine(monkeypatch, _CrashEngine())
+    rule = ExecutableRule(
+        rule_id="grc.security_policy_exists",
+        engine="fake_crash",
+        params={},
+        enforcement="blocking",
+        scope=["**/*.md"],
+    )
+    findings = await execute_rule(rule, _FakeContext([Path("/repo/security-policy.md")]))
+    assert len(findings) == 1
+    assert findings[0].check_id.endswith("enforcement_failure")
+    assert findings[0].evidence_class is EvidenceClass.ATTESTED
+
+
+@pytest.mark.asyncio
+async def test_attestation_is_surfaced_and_labelled_attested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An un-checkable requirement is surfaced as 'needs a human', not skipped."""
+    _patch_engine(monkeypatch, AttestationGateEngine())
+    rule = ExecutableRule(
+        rule_id="grc.controls_appropriate_to_risk",
+        engine="attestation_gate",
+        params={"prompt": "Confirm security controls are appropriate to the risk."},
+        enforcement="reporting",
+        scope=["**/*.md"],
+        is_context_level=True,
+    )
+    findings = await execute_rule(rule, _FakeContext([]))
+    assert len(findings) == 1
+    assert findings[0].evidence_class is EvidenceClass.ATTESTED
+    assert "ATTESTATION REQUIRED" in findings[0].message
+    assert findings[0].check_id == "grc.controls_appropriate_to_risk"
+
+
+@pytest.mark.asyncio
+async def test_attestation_missing_prompt_is_surfaced_not_silent() -> None:
+    """A misconfigured attestation rule surfaces a config finding, never a pass."""
+    engine = AttestationGateEngine()
+    findings = await engine.verify_context(context=None, params={})
+    assert len(findings) == 1
+    assert findings[0].context["finding_type"] == "ATTESTATION_MISCONFIGURED"
+
+
+@pytest.mark.asyncio
+async def test_grc_trio_produces_all_three_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The slice demo: three requirements, three honesty labels in one report."""
+    labels: set[EvidenceClass] = set()
+
+    _patch_engine(monkeypatch, _ProvenEngine())
+    proven = await execute_rule(
+        ExecutableRule("grc.policy_exists", "fake_proven", {}, "blocking", scope=["**/*.md"]),
+        _FakeContext([Path("/repo/policy.md")]),
+    )
+    labels.update(f.evidence_class for f in proven)
+
+    _patch_engine(monkeypatch, _JudgedEngine())
+    judged = await execute_rule(
+        ExecutableRule("grc.mfa_remote", "fake_judged", {}, "reporting", scope=["**/*.md"]),
+        _FakeContext([Path("/repo/policy.md")]),
+    )
+    labels.update(f.evidence_class for f in judged)
+
+    _patch_engine(monkeypatch, AttestationGateEngine())
+    attested = await execute_rule(
+        ExecutableRule(
+            "grc.appropriate_to_risk",
+            "attestation_gate",
+            {"prompt": "Confirm controls are appropriate to the risk."},
+            "reporting",
+            scope=["**/*.md"],
+            is_context_level=True,
+        ),
+        _FakeContext([]),
+    )
+    labels.update(f.evidence_class for f in attested)
+
+    assert labels == {
+        EvidenceClass.PROVEN,
+        EvidenceClass.JUDGED,
+        EvidenceClass.ATTESTED,
+    }


### PR DESCRIPTION
## What

Ratifies **ADR-113** and builds its first slice: every audit finding now declares **how its verdict was established** — `proven` (deterministic), `judged` (AI/semantic), or `attested` (a human must decide). This is the honesty mechanism CORE's GRC gap-analysis (Scenario 4) is sold on, and CORE's own self-audit gains the labels for free.

## How

- `EvidenceClass` enum + field on `AuditFinding` (surfaced in `as_dict()` and an **Evidence** column in the report).
- **Derived from the producing engine, never hand-set** (D2): each engine declares its class; `rule_executor` stamps it onto genuine-verdict findings at the single construction point. 11 deterministic gates → `proven`; `llm_gate`(+stub) → `judged`; new `attestation_gate` → `attested`.
- **Fail-closed** (D3): `BaseEngine` + `AuditFinding` default to `attested`; a crash or an undeclared engine degrades to attested, never a false `proven`.
- **`attested` is surfaced, not skipped** (D4): the new context-level `attestation_gate` emits "HUMAN ATTESTATION REQUIRED — <prompt>", so an un-checkable requirement is the most *visible* line, never a dropped one.

Recon found ~85% already existed (artifact-type registry, glob-driven corpus reading, the proven + judged engines). The only net-new code is the enum+field, per-engine one-liners, the single derivation line, and the attestation engine.

## Also

Withdraws **ADR-112** (BYOR onboard/floor work, Scenario 2), parked by the commercial scoping decision to focus on CORE-on-CORE + GRC gap-analysis.

## Verification

- `ruff check` clean on all touched files.
- Async smoke of the real `execute_rule` path: trio (proven/judged/attested) all produced; a crashed `proven` engine degrades to `attested`.
- **D6 + regression:** CORE's own offline self-audit runs clean — all 291 findings now carry an honest `proven` label.
- Tests in `tests/mind/governance/test_evidence_class__adr113.py` (declarations, derivation, fail-closed, attestation surfacing, the trio). `pytest` not run in-session — governor verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)