### PR TITLE
feat(grc): customer-facing GRC gap-analysis demo (Scenario 4)

### DIFF
--- a/src/body/services/grc/__init__.py
+++ b/src/body/services/grc/__init__.py
@@ -1,0 +1,25 @@
+# src/body/services/grc/__init__.py
+"""GRC (Governance, Risk, Compliance) gap-analysis — the Scenario-4 service.
+
+Runs a maintained catalog of checkable compliance requirements (the Intent)
+against a customer's document corpus (the Artifact) and returns a gap report
+where every finding carries its ADR-113 evidence class — proven / judged /
+attested. This is the hosted-service shape: it drives the same constitutional
+engine CORE runs on itself, decoupling the requirements catalog from the corpus
+location, rather than installing CORE inside the customer's repository.
+"""
+
+from __future__ import annotations
+
+from body.services.grc.gap_analysis_service import (
+    GRCGapAnalysisService,
+    RequirementResult,
+    load_demo_catalog,
+)
+
+
+__all__ = [
+    "GRCGapAnalysisService",
+    "RequirementResult",
+    "load_demo_catalog",
+]

--- a/src/body/services/grc/gap_analysis_service.py
+++ b/src/body/services/grc/gap_analysis_service.py
@@ -1,0 +1,231 @@
+# src/body/services/grc/gap_analysis_service.py
+"""GRC gap-analysis service (Scenario 4).
+
+Drives the constitutional engine over an (Intent, Artifact) pair where the two
+live in different places:
+
+- **Intent** — a maintained catalog of checkable compliance requirements,
+  expressed as ``ExecutableRule``s (each bound to a verification engine).
+- **Artifact** — a folder of the customer's documents (the corpus).
+
+Each requirement runs through the real ``execute_rule`` path, so findings carry
+their ADR-113 ``evidence_class`` (proven / judged / attested) with no audit-loop
+duplication. The corpus is read by a purpose-built context whose ``get_files``
+globs the corpus directly — the standard ``AuditorContext`` derives its file walk
+from the *loaded* intent's rule scopes, which would not see an external corpus.
+
+The catalog here is a small demo (``load_demo_catalog``). The maintained,
+regulation-derived catalog — the product — is a later build (the RegTech work);
+this proves the engine shape on documents.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+from mind.governance.executable_rule import ExecutableRule
+from mind.governance.rule_executor import execute_rule
+from shared.logger import getLogger
+from shared.models import AuditFinding, EvidenceClass
+
+
+logger = getLogger(__name__)
+
+
+# ID: 5128f744-4412-467e-89a6-d5e9f748ff6e
+class _CorpusContext:
+    """Minimal context for ``execute_rule`` that reads a document corpus.
+
+    Implements only the surface ``execute_rule`` touches: ``repo_path``,
+    ``get_files`` (globs the corpus), and ``force_llm``. Decouples the Artifact
+    (corpus) from the Intent (catalog) — the requirement's scope globs the
+    corpus directly rather than the loaded-intent-derived walk.
+    """
+
+    def __init__(self, corpus_root: Path) -> None:
+        self.repo_path = corpus_root.resolve()
+        self.force_llm = False
+
+    # ID: ac2dee70-0f89-473a-beac-e46c2a39a0de
+    def get_files(self, include: Any, exclude: Any = None) -> list[Path]:
+        includes = list(include or [])
+        excludes = list(exclude or [])
+        out: set[Path] = set()
+        for pattern in includes:
+            for path in self.repo_path.glob(pattern):
+                if not path.is_file():
+                    continue
+                rel = path.relative_to(self.repo_path).as_posix()
+                if any(fnmatch(rel, e) for e in excludes):
+                    continue
+                out.add(path)
+        return sorted(out)
+
+
+@dataclass
+# ID: b8fdcb87-2b2d-4425-8b25-301295aa84b7
+class RequirementResult:
+    """One requirement's gap-analysis outcome, with its honesty label."""
+
+    rule: ExecutableRule
+    evidence_class: EvidenceClass
+    findings: list[AuditFinding]
+    status: str  # "gap" | "met" | "needs_human" | "pending_ai"
+
+    @property
+    # ID: bbb2aaa4-d607-4191-8d54-06dc5b2470e3
+    def requirement_id(self) -> str:
+        return self.rule.rule_id
+
+    @property
+    # ID: 8683f78b-0711-479a-ad33-dc0e833319b7
+    def statement(self) -> str:
+        return self.rule.statement
+
+
+# ID: b4172354-bcf6-4a94-9e36-a78bb47a8c28
+def load_demo_catalog() -> list[ExecutableRule]:
+    """A 3-requirement demo catalog, one per honesty label.
+
+    Illustrative only — not authored from a real standard. The maintained,
+    regulation-derived catalog is the product (a later build).
+    """
+    return [
+        # PROVEN — deterministic: a finalized policy carries no placeholder text.
+        ExecutableRule(
+            rule_id="grc.demo.policy_is_finalized",
+            engine="regex_gate",
+            params={
+                "forbidden_patterns": [
+                    r"\bTBD\b",
+                    r"\bTODO\b",
+                    r"\bDRAFT\b",
+                    r"\bFIXME\b",
+                    r"<placeholder>",
+                ]
+            },
+            enforcement="blocking",
+            statement=(
+                "Compliance policy documents MUST be finalized — no placeholder, "
+                "TODO, TBD, DRAFT, or FIXME text."
+            ),
+            scope=["**/*.md", "**/*.txt"],
+        ),
+        # JUDGED — semantic: needs an AI reading of the policy text.
+        ExecutableRule(
+            rule_id="grc.demo.requires_mfa_for_remote_access",
+            engine="llm_gate",
+            params={
+                "check_type": "semantic_requirement",
+                "requirement": (
+                    "The access-control policy requires multi-factor "
+                    "authentication for all remote access."
+                ),
+            },
+            enforcement="reporting",
+            statement=(
+                "The access-control policy MUST require multi-factor "
+                "authentication for all remote access."
+            ),
+            scope=["**/*.md", "**/*.txt"],
+        ),
+        # ATTESTED — irreducibly human: no automated method can settle it.
+        ExecutableRule(
+            rule_id="grc.demo.controls_appropriate_to_risk",
+            engine="attestation_gate",
+            params={
+                "prompt": (
+                    "Confirm that the documented security controls are "
+                    "appropriate to the organization's assessed risk profile."
+                ),
+                "reference": "ISO/IEC 27001:2022 Clauses 6.1.3 / 8.3",
+            },
+            enforcement="reporting",
+            statement=(
+                "Security controls MUST be appropriate to the organization's "
+                "assessed risk profile."
+            ),
+            scope=["**/*.md", "**/*.txt"],
+            is_context_level=True,
+        ),
+    ]
+
+
+# ID: fcf7ed3d-ea95-43c6-8333-ca0555387217
+class GRCGapAnalysisService:
+    """Runs a requirements catalog against a document corpus → gap report.
+
+    Read-only: it reads the corpus and reports gaps; it never modifies the
+    customer's documents (the GRC autonomy ceiling, CORE-BYOR §5 parameter 3).
+    """
+
+    # ID: 40434806-a71e-45cf-912f-762db4613c65
+    def __init__(self, llm_client: Any | None = None) -> None:
+        # When an LLM client is wired, the judged requirement produces a real
+        # AI verdict; without one it degrades honestly to "pending_ai".
+        self._llm_client = llm_client
+
+    # ID: 483bbcf4-2f5f-4dea-9542-2b18689adf33
+    async def run(
+        self, corpus_root: Path, catalog: list[ExecutableRule] | None = None
+    ) -> list[RequirementResult]:
+        """Evaluate every requirement against the corpus.
+
+        Args:
+            corpus_root: folder holding the customer's documents (the Artifact).
+            catalog: the requirements to check (the Intent). Defaults to the
+                demo catalog.
+
+        Returns one ``RequirementResult`` per requirement, each carrying its
+        findings and an honest status.
+        """
+        from mind.logic.engines.registry import EngineRegistry
+        from shared.config import settings
+
+        # Engine internals (e.g. llm_gate prompts under var/prompts/) resolve
+        # against CORE's own root; the corpus is addressed only via the
+        # _CorpusContext below. Two independent roots — the Intent/Artifact split.
+        EngineRegistry.initialize(settings.paths, llm_client=self._llm_client)
+
+        context = _CorpusContext(corpus_root)
+        results: list[RequirementResult] = []
+        for rule in catalog or load_demo_catalog():
+            findings = await execute_rule(rule, context)  # type: ignore[arg-type]
+            results.append(self._classify(rule, findings))
+        return results
+
+    # ID: ece0623b-502c-41e0-9cd6-1f8dfd7fe69b
+    def _classify(
+        self, rule: ExecutableRule, findings: list[AuditFinding]
+    ) -> RequirementResult:
+        """Derive the requirement's status + its declared evidence class.
+
+        The declared class comes from the producing engine (proven/judged/
+        attested). A judged requirement whose AI pass did not run (llm_gate fell
+        back to the stub, no client wired) is reported honestly as ``pending_ai``
+        — never as met and never as a real judged verdict.
+        """
+        from mind.logic.engines.registry import EngineRegistry
+
+        engine = EngineRegistry.get(rule.engine)
+        declared = getattr(engine, "evidence_class", EvidenceClass.ATTESTED)
+
+        is_stub = any(f.context.get("stub") for f in findings)
+        if declared is EvidenceClass.ATTESTED:
+            status = "needs_human"
+        elif is_stub:
+            status = "pending_ai"
+        elif findings:
+            status = "gap"
+        else:
+            status = "met"
+
+        return RequirementResult(
+            rule=rule,
+            evidence_class=declared,
+            findings=findings,
+            status=status,
+        )

--- a/src/cli/admin_cli.py
+++ b/src/cli/admin_cli.py
@@ -29,6 +29,7 @@ from cli.resources.constitution import app as constitution_app
 from cli.resources.context import app as context_app
 from cli.resources.database import app as database_app
 from cli.resources.dev import app as dev_app
+from cli.resources.grc import app as grc_app
 from cli.resources.intent import app as intent_app
 from cli.resources.lane import app as lane_app
 from cli.resources.project import app as project_app
@@ -69,6 +70,7 @@ def register_all_commands(app_instance: typer.Typer) -> None:
     app_instance.add_typer(proposals_app, name="proposals")
     app_instance.add_typer(lane_app, name="lane")
     app_instance.add_typer(project_app, name="project")
+    app_instance.add_typer(grc_app, name="grc")
     app_instance.add_typer(dev_app, name="dev")
     app_instance.add_typer(intent_app, name="intent")
     app_instance.add_typer(interactive_test_app, name="interactive-test")

--- a/src/cli/resources/grc/__init__.py
+++ b/src/cli/resources/grc/__init__.py
@@ -1,0 +1,18 @@
+# src/cli/resources/grc/__init__.py
+"""GRC (Governance, Risk, Compliance) gap-analysis commands."""
+
+from __future__ import annotations
+
+import typer
+
+
+app = typer.Typer(
+    name="grc",
+    help="Compliance gap-analysis: check a document corpus against a requirements catalog.",
+    no_args_is_help=True,
+)
+
+from . import gap_analysis  # registers the gap-analysis command on `app`
+
+
+__all__ = ["app"]

--- a/src/cli/resources/grc/gap_analysis.py
+++ b/src/cli/resources/grc/gap_analysis.py
@@ -1,0 +1,118 @@
+# src/cli/resources/grc/gap_analysis.py
+"""`core-admin grc gap-analysis <corpus>` — the customer-facing GRC demo.
+
+Points the constitutional engine at a folder of documents (the customer's
+"documentation stack") and prints a gap report against a compliance
+requirements catalog, with every line honestly labelled by how its verdict was
+established — proven / judged / needs-human (ADR-113).
+
+Read-only: it reads the corpus and reports; it never modifies the documents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from body.services.grc import GRCGapAnalysisService, RequirementResult
+from cli.utils import core_command
+from shared.models import EvidenceClass
+
+from . import app
+
+
+console = Console()
+
+_EVIDENCE_STYLE = {
+    EvidenceClass.PROVEN: "[green]proven[/green]",
+    EvidenceClass.JUDGED: "[yellow]judged[/yellow]",
+    EvidenceClass.ATTESTED: "[magenta]needs human[/magenta]",
+}
+
+_STATUS_STYLE = {
+    "gap": "[bold red]GAP[/bold red]",
+    "met": "[green]met[/green]",
+    "needs_human": "[magenta]needs human sign-off[/magenta]",
+    "pending_ai": "[yellow]AI evaluation pending[/yellow]",
+}
+
+
+# ID: 00bb5176-1308-4695-a0c2-02ffbcbe5295
+def _render_report(corpus: Path, results: list[RequirementResult]) -> None:
+    """Print the traceability matrix: requirement → evidence class → status."""
+    table = Table(
+        title=f"[bold]GRC Gap Report[/bold] — {corpus}",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("Requirement", style="cyan", overflow="fold")
+    table.add_column("Evidence", style="white")
+    table.add_column("Status", style="white")
+    table.add_column("Detail", style="white", overflow="fold")
+
+    for r in results:
+        if r.status == "gap":
+            detail = r.findings[0].message if r.findings else ""
+        elif r.status == "needs_human":
+            prompt = (
+                r.findings[0].context.get("attestation_prompt", "")
+                if r.findings
+                else ""
+            )
+            detail = prompt
+        elif r.status == "pending_ai":
+            detail = "Requires an AI evaluation pass (run with an LLM provider wired)."
+        else:
+            detail = "No gap found by the deterministic check."
+        table.add_row(
+            r.statement,
+            _EVIDENCE_STYLE.get(r.evidence_class, str(r.evidence_class)),
+            _STATUS_STYLE.get(r.status, r.status),
+            detail,
+        )
+
+    console.print(table)
+
+    gaps = sum(1 for r in results if r.status == "gap")
+    human = sum(1 for r in results if r.status == "needs_human")
+    pending = sum(1 for r in results if r.status == "pending_ai")
+    console.print(
+        f"\n[bold]{len(results)} requirements[/bold] · "
+        f"[red]{gaps} gap(s) proven[/red] · "
+        f"[magenta]{human} need human sign-off[/magenta] · "
+        f"[yellow]{pending} pending AI[/yellow]"
+    )
+    console.print(
+        "[dim]Every line states how its verdict was reached. CORE reports only "
+        "what it can defend — proven, judged, or handed to your reviewer.[/dim]"
+    )
+
+
+@app.command("gap-analysis")
+@core_command(dangerous=False, requires_context=False, offline_capable=True)
+# ID: 67729121-d5f3-4fd5-95ae-62eac24a1e8e
+async def gap_analysis(
+    ctx: typer.Context,
+    corpus: Path = typer.Argument(
+        ...,
+        help="Folder of documents to analyse (the customer's documentation stack).",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+    ),
+) -> None:
+    """Run the demo compliance catalog against a folder of documents.
+
+    Produces a gap report where each requirement is labelled by how its verdict
+    was established: proven (deterministic), judged (AI), or attested (needs a
+    human). The demo catalog is illustrative; the maintained, regulation-derived
+    catalog is the product.
+    """
+    console.print(
+        f"[bold cyan]🔎 GRC gap-analysis[/bold cyan] over [bold]{corpus}[/bold]"
+    )
+    results = await GRCGapAnalysisService().run(corpus.resolve())
+    _render_report(corpus, results)

--- a/tests/body/services/grc/test_gap_analysis_service.py
+++ b/tests/body/services/grc/test_gap_analysis_service.py
@@ -1,0 +1,61 @@
+"""GRC gap-analysis service — the customer-facing Scenario-4 slice.
+
+Proves the engine runs a compliance requirements catalog (Intent) against a
+document corpus (Artifact) and returns a gap report where each requirement is
+honestly labelled by how its verdict was established (ADR-113):
+
+- a deterministic check finds a real gap and labels it **proven**;
+- an irreducibly-human requirement is surfaced as **attested** / needs-human,
+  never silently skipped;
+- the AI-judgment requirement is labelled **judged** and, with no LLM wired in
+  the test, degrades honestly to `pending_ai` — never a fabricated verdict and
+  never silently "met".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from body.services.grc import GRCGapAnalysisService
+from shared.models import EvidenceClass
+
+
+_CORPUS = Path(__file__).parents[3] / "fixtures" / "grc" / "corpus"
+
+
+@pytest.mark.asyncio
+async def test_gap_analysis_produces_labelled_trio() -> None:
+    results = await GRCGapAnalysisService().run(_CORPUS)
+    by_id = {r.requirement_id: r for r in results}
+    assert len(results) == 3
+
+    # PROVEN — the planted "TBD" in the encryption section is a real gap.
+    proven = by_id["grc.demo.policy_is_finalized"]
+    assert proven.evidence_class is EvidenceClass.PROVEN
+    assert proven.status == "gap"
+    assert proven.findings
+    assert any("TBD" in f.message for f in proven.findings)
+
+    # JUDGED — AI dimension, no LLM wired in the test → honest pending, not met.
+    judged = by_id["grc.demo.requires_mfa_for_remote_access"]
+    assert judged.evidence_class is EvidenceClass.JUDGED
+    assert judged.status == "pending_ai"
+
+    # ATTESTED — surfaced for a human, never skipped.
+    attested = by_id["grc.demo.controls_appropriate_to_risk"]
+    assert attested.evidence_class is EvidenceClass.ATTESTED
+    assert attested.status == "needs_human"
+    assert attested.findings
+
+
+@pytest.mark.asyncio
+async def test_clean_corpus_reports_proven_met(tmp_path: Path) -> None:
+    """A finalized policy (no placeholder text) yields no proven gap."""
+    doc = tmp_path / "policy.md"
+    doc.write_text("# Policy\n\nAll controls are documented and finalized.\n", encoding="utf-8")
+    results = await GRCGapAnalysisService().run(tmp_path)
+    proven = next(r for r in results if r.requirement_id == "grc.demo.policy_is_finalized")
+    assert proven.status == "met"
+    assert not proven.findings

--- a/tests/fixtures/grc/corpus/access-control-policy.md
+++ b/tests/fixtures/grc/corpus/access-control-policy.md
@@ -1,0 +1,14 @@
+# Access Control Policy
+
+**Owner:** Head of IT Security
+**Review cadence:** Annual
+
+## 1. Authentication
+All employees authenticate with a unique corporate identity.
+
+## 2. Remote Access
+Remote access to internal systems is permitted only through the corporate VPN.
+Passwords are rotated every 90 days.
+
+## 3. Privileged Access
+Administrative access requires a separate privileged account and is logged.

--- a/tests/fixtures/grc/corpus/information-security-policy.md
+++ b/tests/fixtures/grc/corpus/information-security-policy.md
@@ -1,0 +1,17 @@
+# Information Security Policy
+
+**Owner:** Chief Information Security Officer
+**Review cadence:** Annual
+
+## 1. Purpose
+This policy defines how the organization protects the confidentiality,
+integrity, and availability of information assets.
+
+## 2. Access Control
+Access to systems is granted on a least-privilege basis and reviewed quarterly.
+
+## 3. Encryption
+Data-at-rest and data-in-transit encryption standards: TBD.
+
+## 4. Incident Response
+Security incidents are reported to the CISO within 24 hours.


### PR DESCRIPTION
## What

Adds **`core-admin grc gap-analysis <corpus>`** — point it at a folder of documents (the customer's documentation stack) and get back a gap report where **every requirement is labelled by how its verdict was established**: `proven` (deterministic), `judged` (AI), or `needs-human` (attested). Builds on ADR-113.

## How

- `src/body/services/grc/` — `GRCGapAnalysisService` runs a requirements catalog (the **Intent**) against a document corpus (the **Artifact**), decoupled. It reuses the real `execute_rule` path, so findings carry their `evidence_class` with **no audit-loop duplication**. A `_CorpusContext` globs the corpus directly (the standard `AuditorContext` walk is tied to the loaded intent's scopes and would not see an external corpus). **Read-only** — never modifies the customer's documents (the GRC autonomy ceiling).
- `src/cli/resources/grc/` — the command + a traceability-matrix renderer (Requirement → Evidence → Status → Detail), registered in `admin_cli.py`.

## Live output (against the fixture corpus)

```
3 requirements · 1 gap(s) proven · 1 need human sign-off · 1 pending AI
```
- **proven → GAP** — finds the planted "TBD" in a policy doc.
- **judged → AI evaluation pending** — `llm_gate` degrades honestly with no LLM wired; never a fabricated verdict, never silently "met".
- **attested → needs human sign-off** — surfaced, not skipped.

## Honest scope

- **`judged` is "pending" by design here.** A real AI verdict needs a regulation-derived prompt/contract for `llm_gate` — part of the maintained catalog (the RegTech build), deliberately out of this slice.
- **The catalog is a code-defined demo** (`load_demo_catalog`), illustrative, not from a real standard. The maintained, data-driven, regulation-derived catalog is the product and the next build.

## Verification

- `ruff check` clean.
- Tests: `tests/body/services/grc/test_gap_analysis_service.py` (the labelled trio + a clean-corpus "met" case) — **2 passed**. Live CLI smoke against `tests/fixtures/grc/corpus/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)