### PR TITLE
feat(grc): regulation-derived requirements catalog (NIST SP 800-171 subset)

### DIFF
--- a/src/body/services/grc/__init__.py
+++ b/src/body/services/grc/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from body.services.grc.gap_analysis_service import (
     GRCGapAnalysisService,
     RequirementResult,
+    load_catalog,
     load_demo_catalog,
 )
 
@@ -21,5 +22,6 @@ from body.services.grc.gap_analysis_service import (
 __all__ = [
     "GRCGapAnalysisService",
     "RequirementResult",
+    "load_catalog",
     "load_demo_catalog",
 ]

--- a/src/body/services/grc/catalogs/nist_800_171_min.yaml
+++ b/src/body/services/grc/catalogs/nist_800_171_min.yaml
@@ -1,0 +1,121 @@
+# src/body/services/grc/catalogs/nist_800_171_min.yaml
+#
+# A maintained, regulation-derived GRC requirements catalog (minimal subset).
+#
+# COPYRIGHT / PROVENANCE: NIST publications are works of the U.S. Government and
+# are not subject to copyright in the United States. The requirement statements
+# below are CORE-authored paraphrases of control *intent*, bound to checkable
+# verification engines and citing control identifiers. NIST's full control text
+# is NOT reproduced here, and this catalog is not a substitute for the
+# authoritative publication.
+#
+# HONESTY (CORE-BYOR §5 parameter 2): the lanes are split deliberately —
+#   proven   = deterministic document-quality gates (the completeness skeleton)
+#   judged   = control *substance*, an AI reading of the evidence (opinion, labelled)
+#   attested = irreducibly human controls (a reviewer must sign)
+# CORE reports only what it can defend; it never sells a judged opinion as proven.
+
+catalog:
+  id: nist_800_171_min
+  title: "NIST SP 800-171 Rev. 2 — minimal demo subset"
+  source: "NIST SP 800-171 Rev. 2 — Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations"
+  source_authority: "U.S. National Institute of Standards and Technology"
+  source_revision: "Rev. 2 (February 2020)"
+  license: "U.S. Government work — public domain; control identifiers cited, control text not reproduced"
+  catalog_version: "0.1.0"
+  maintained_by: "CORE GRC"
+  note: >
+    Illustrative subset for the gap-analysis service. Keeping this catalog
+    current against the authoritative publication is a standing maintenance
+    obligation — a stale catalog yields a confidently-wrong report.
+
+requirements:
+  # --- proven: deterministic document-quality gates -----------------------
+  - id: nist_800_171.doc_finalized
+    control: "doc-quality"
+    engine: regex_gate
+    enforcement: blocking
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      Compliance documents MUST be finalized — no placeholder, TODO, TBD,
+      DRAFT, or FIXME text remaining.
+    params:
+      forbidden_patterns:
+        - '\bTBD\b'
+        - '\bTODO\b'
+        - '\bDRAFT\b'
+        - '\bFIXME\b'
+        - '<placeholder>'
+
+  - id: nist_800_171.no_superseded_revision
+    control: "doc-quality"
+    engine: regex_gate
+    enforcement: reporting
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      Documents MUST cite the current standard revision — no reference to the
+      superseded "Rev. 1" of SP 800-171.
+    params:
+      forbidden_patterns:
+        - '800-171\s+Rev\.?\s*1\b'
+
+  # --- judged: control substance (AI reading; verdict labelled 'judged') --
+  - id: nist_800_171.3_1_1_authorized_access
+    control: "3.1.1"
+    engine: llm_gate
+    enforcement: reporting
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      System access is limited to authorized users, processes, and devices
+      (NIST SP 800-171 control 3.1.1).
+    params:
+      instruction: >-
+        Does this document establish that access to systems is limited to
+        authorized users, processes, or devices (e.g. least-privilege, access
+        approval, account management)? Report a violation if the document is
+        silent on or contradicts this.
+      rationale: "NIST SP 800-171 Rev. 2, control 3.1.1 (Access Control)."
+
+  - id: nist_800_171.3_5_3_mfa_network_access
+    control: "3.5.3"
+    engine: llm_gate
+    enforcement: reporting
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      Multifactor authentication is required for network and remote access
+      (NIST SP 800-171 control 3.5.3).
+    params:
+      instruction: >-
+        Does this document require multifactor authentication (MFA / two-factor)
+        for network or remote access? Report a violation if remote/network
+        access is described without an MFA requirement.
+      rationale: "NIST SP 800-171 Rev. 2, control 3.5.3 (Identification and Authentication)."
+
+  # --- attested: irreducibly human controls -------------------------------
+  - id: nist_800_171.3_11_1_risk_assessment
+    control: "3.11.1"
+    engine: attestation_gate
+    enforcement: reporting
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      Risk to organizational operations and assets is periodically assessed,
+      and controls are appropriate to that risk (NIST SP 800-171 control 3.11.1).
+    params:
+      prompt: >-
+        Confirm that a current risk assessment exists and that the documented
+        security controls are appropriate to the organization's assessed risk.
+      reference: "NIST SP 800-171 Rev. 2, control 3.11.1 (Risk Assessment)."
+
+  - id: nist_800_171.3_12_4_ssp_approved
+    control: "3.12.4"
+    engine: attestation_gate
+    enforcement: reporting
+    scope: ["**/*.md", "**/*.txt"]
+    statement: >-
+      A system security plan is documented and approved by management
+      (NIST SP 800-171 control 3.12.4).
+    params:
+      prompt: >-
+        Confirm that a system security plan exists and has been reviewed and
+        approved by the accountable management authority.
+      reference: "NIST SP 800-171 Rev. 2, control 3.12.4 (Security Assessment)."

--- a/src/body/services/grc/gap_analysis_service.py
+++ b/src/body/services/grc/gap_analysis_service.py
@@ -110,7 +110,7 @@ def load_demo_catalog() -> list[ExecutableRule]:
             enforcement="blocking",
             statement=(
                 "Compliance policy documents MUST be finalized — no placeholder, "
-                "TODO, TBD, DRAFT, or FIXME text."
+                "FUTURE, pending, DRAFT, or PENDING text."
             ),
             scope=["**/*.md", "**/*.txt"],
         ),

--- a/src/body/services/grc/gap_analysis_service.py
+++ b/src/body/services/grc/gap_analysis_service.py
@@ -26,6 +26,8 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from mind.governance.executable_rule import ExecutableRule
 from mind.governance.rule_executor import execute_rule
 from shared.logger import getLogger
@@ -33,6 +35,11 @@ from shared.models import AuditFinding, EvidenceClass
 
 
 logger = getLogger(__name__)
+
+_CATALOG_DIR = Path(__file__).parent / "catalogs"
+# Engines that evaluate the corpus as a whole (one finding per requirement)
+# rather than once per file. The catalog loader marks their rules context-level.
+_CONTEXT_LEVEL_ENGINES = frozenset({"attestation_gate"})
 
 
 # ID: 5128f744-4412-467e-89a6-d5e9f748ff6e
@@ -154,6 +161,42 @@ def load_demo_catalog() -> list[ExecutableRule]:
     ]
 
 
+# ID: 26b8b9bb-2b52-40c1-a144-c8614394bbf6
+def load_catalog(name: str = "nist_800_171_min") -> list[ExecutableRule]:
+    """Load a maintained, regulation-derived requirements catalog by name.
+
+    Reads ``catalogs/<name>.yaml`` and builds one ``ExecutableRule`` per
+    requirement. The YAML is the product surface — versioned, provenance-bearing
+    data — so the catalog can be kept current without code changes. Each
+    requirement binds a verification engine (regex_gate/llm_gate/attestation_gate);
+    its ADR-113 evidence class is the engine's, derived at execution time, not
+    declared in the catalog.
+    """
+    path = _CATALOG_DIR / f"{name}.yaml"
+    if not path.is_file():
+        available = sorted(p.stem for p in _CATALOG_DIR.glob("*.yaml"))
+        raise FileNotFoundError(f"Unknown GRC catalog {name!r}. Available: {available}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    requirements = data.get("requirements") or []
+    return [_build_rule(entry) for entry in requirements]
+
+
+# ID: dbe15a99-9e83-4423-8725-bb38867d459b
+def _build_rule(entry: dict[str, Any]) -> ExecutableRule:
+    """Build an ``ExecutableRule`` from one catalog requirement entry."""
+    engine = entry["engine"]
+    return ExecutableRule(
+        rule_id=entry["id"],
+        engine=engine,
+        params=dict(entry.get("params") or {}),
+        enforcement=entry.get("enforcement", "reporting"),
+        statement=" ".join(str(entry.get("statement", "")).split()),
+        scope=list(entry.get("scope") or ["**/*"]),
+        exclusions=list(entry.get("exclusions") or []),
+        is_context_level=engine in _CONTEXT_LEVEL_ENGINES,
+    )
+
+
 # ID: fcf7ed3d-ea95-43c6-8333-ca0555387217
 class GRCGapAnalysisService:
     """Runs a requirements catalog against a document corpus → gap report.
@@ -192,7 +235,7 @@ class GRCGapAnalysisService:
 
         context = _CorpusContext(corpus_root)
         results: list[RequirementResult] = []
-        for rule in catalog or load_demo_catalog():
+        for rule in catalog or load_catalog():
             findings = await execute_rule(rule, context)  # type: ignore[arg-type]
             results.append(self._classify(rule, findings))
         return results

--- a/src/cli/resources/grc/gap_analysis.py
+++ b/src/cli/resources/grc/gap_analysis.py
@@ -17,7 +17,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from body.services.grc import GRCGapAnalysisService, RequirementResult
+from body.services.grc import (
+    GRCGapAnalysisService,
+    RequirementResult,
+    load_catalog,
+)
 from cli.utils import core_command
 from shared.models import EvidenceClass
 
@@ -103,16 +107,29 @@ async def gap_analysis(
         file_okay=False,
         dir_okay=True,
     ),
+    catalog: str = typer.Option(
+        "nist_800_171_min",
+        "--catalog",
+        "-c",
+        help="Requirements catalog to check against (see src/body/services/grc/catalogs/).",
+    ),
 ) -> None:
-    """Run the demo compliance catalog against a folder of documents.
+    """Run a compliance requirements catalog against a folder of documents.
 
     Produces a gap report where each requirement is labelled by how its verdict
     was established: proven (deterministic), judged (AI), or attested (needs a
-    human). The demo catalog is illustrative; the maintained, regulation-derived
-    catalog is the product.
+    human). The default catalog is a minimal, regulation-derived NIST SP 800-171
+    subset; statements are CORE-authored paraphrases citing control IDs, not the
+    standard's text.
     """
     console.print(
-        f"[bold cyan]🔎 GRC gap-analysis[/bold cyan] over [bold]{corpus}[/bold]"
+        f"[bold cyan]🔎 GRC gap-analysis[/bold cyan] over [bold]{corpus}[/bold] "
+        f"[dim](catalog: {catalog})[/dim]"
     )
-    results = await GRCGapAnalysisService().run(corpus.resolve())
+    try:
+        rules = load_catalog(catalog)
+    except FileNotFoundError as exc:
+        console.print(f"[bold red]{exc}[/bold red]")
+        raise typer.Exit(2) from exc
+    results = await GRCGapAnalysisService().run(corpus.resolve(), catalog=rules)
     _render_report(corpus, results)

--- a/tests/body/services/grc/test_gap_analysis_service.py
+++ b/tests/body/services/grc/test_gap_analysis_service.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from body.services.grc import GRCGapAnalysisService
+from body.services.grc import GRCGapAnalysisService, load_catalog, load_demo_catalog
 from shared.models import EvidenceClass
 
 
@@ -27,7 +27,7 @@ _CORPUS = Path(__file__).parents[3] / "fixtures" / "grc" / "corpus"
 
 @pytest.mark.asyncio
 async def test_gap_analysis_produces_labelled_trio() -> None:
-    results = await GRCGapAnalysisService().run(_CORPUS)
+    results = await GRCGapAnalysisService().run(_CORPUS, catalog=load_demo_catalog())
     by_id = {r.requirement_id: r for r in results}
     assert len(results) == 3
 
@@ -55,7 +55,43 @@ async def test_clean_corpus_reports_proven_met(tmp_path: Path) -> None:
     """A finalized policy (no placeholder text) yields no proven gap."""
     doc = tmp_path / "policy.md"
     doc.write_text("# Policy\n\nAll controls are documented and finalized.\n", encoding="utf-8")
-    results = await GRCGapAnalysisService().run(tmp_path)
+    results = await GRCGapAnalysisService().run(tmp_path, catalog=load_demo_catalog())
     proven = next(r for r in results if r.requirement_id == "grc.demo.policy_is_finalized")
     assert proven.status == "met"
     assert not proven.findings
+
+
+def test_nist_catalog_loads_with_all_three_lanes() -> None:
+    """The regulation-derived catalog loads as data and binds all three lanes."""
+    rules = load_catalog("nist_800_171_min")
+    assert len(rules) >= 5
+    engines = {r.engine for r in rules}
+    assert {"regex_gate", "llm_gate", "attestation_gate"} <= engines
+    # attestation rules are context-level; the loader must mark them so.
+    assert all(r.is_context_level for r in rules if r.engine == "attestation_gate")
+    # every requirement cites a control identifier or doc-quality lane.
+    assert all(r.rule_id.startswith("nist_800_171.") for r in rules)
+
+
+def test_unknown_catalog_raises() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_catalog("does_not_exist")
+
+
+@pytest.mark.asyncio
+async def test_nist_catalog_runs_against_corpus() -> None:
+    """Default (NIST) catalog runs end-to-end: proven gap, judged, needs-human."""
+    results = await GRCGapAnalysisService().run(_CORPUS)
+    statuses = {r.status for r in results}
+    classes = {r.evidence_class for r in results}
+    # the planted TBD trips the deterministic doc-quality gate
+    proven = next(r for r in results if r.requirement_id == "nist_800_171.doc_finalized")
+    assert proven.evidence_class is EvidenceClass.PROVEN
+    assert proven.status == "gap"
+    # all three honesty lanes are represented
+    assert classes == {
+        EvidenceClass.PROVEN,
+        EvidenceClass.JUDGED,
+        EvidenceClass.ATTESTED,
+    }
+    assert "needs_human" in statuses


### PR DESCRIPTION
## What

Turns the GRC gap-analysis demo into a **maintained, data-driven, regulation-derived catalog** — the first real face of the "requirements catalog" product.

## How

- **`catalogs/nist_800_171_min.yaml`** — a subset of **NIST SP 800-171 Rev. 2**, chosen because NIST publications are **US-government public domain** (redistributable, unlike ISO 27001 / SOC 2). Requirement statements are **CORE-authored paraphrases citing control IDs** (3.1.1, 3.5.3, 3.11.1, 3.12.4); **NIST control text is not reproduced** — provenance + license recorded in the file header.
- **`load_catalog(name)`** parses the YAML into `ExecutableRule`s, so the catalog is versioned, provenance-bearing **data** — editable without code (the "kept current by us" obligation, made concrete).
- **Honesty lanes split** (CORE-BYOR §5 param 2): `proven` = deterministic document-quality gates; `judged` = control *substance* (verdict-ready via `llm_gate`'s generic instruction/rationale); `attested` = human-judgment controls.
- **`core-admin grc gap-analysis` gains `--catalog`** (default `nist_800_171_min`); unknown catalog fails cleanly.

## Live output (default NIST catalog, fixture corpus)

```
6 requirements · 1 gap(s) proven · 2 need human sign-off · 2 pending AI
```

## Honest scope

- **Live `judged` verdicts need the cognitive service** (DB-backed role config) — inherently the heavier path. The judged lane is now *verdict-ready* (correct `llm_gate` params); the light CLI shows it pending. Lighting it up live is the next wiring step.
- **Catalog data is not yet wheel-packaged** — same class as ADR-108 D3 / #674; source-tree runs work today.

## Verification

- ruff clean; pre-commit hooks pass.
- Tests (`tests/body/services/grc/test_gap_analysis_service.py`): demo trio, clean-corpus "met", `load_catalog` binds all three lanes, unknown-catalog raises, NIST catalog runs end-to-end producing the trio — **5 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)