### PR TITLE
fix(grc): restore demo-catalog sentence corrupted by fix.placeholders

### DIFF
--- a/src/body/services/grc/gap_analysis_service.py
+++ b/src/body/services/grc/gap_analysis_service.py
@@ -117,7 +117,7 @@ def load_demo_catalog() -> list[ExecutableRule]:
             enforcement="blocking",
             statement=(
                 "Compliance policy documents MUST be finalized — no placeholder, "
-                "FUTURE, pending, DRAFT, or PENDING text."
+                "TODO, TBD, DRAFT, or FIXME text."
             ),
             scope=["**/*.md", "**/*.txt"],
         ),


### PR DESCRIPTION
One-line regression fix. The demo requirement's statement read "no placeholder, FUTURE, pending, DRAFT, or PENDING text" — inconsistent with the `TODO`/`TBD`/`DRAFT`/`FIXME` patterns it actually checks. That wrong wording came from the daemon's `fix.placeholders` rewrite. ADR-114 (#679) restored it, but #678 merged afterward carrying the pre-fix line and clobbered the fix. With `purity.no_todo_placeholders` retired (#679), the correct wording is now stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)