### PR TITLE
fix(ci): address pre-existing CORE CI red checks (#631, PR-linter, stateless warm-up)

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -88,12 +88,16 @@ jobs:
     steps:
       - name: Check PR Body for Intent & Justification
         id: check_body
+        # PR body is passed via env, never interpolated inline into the script:
+        # an inline ${{ ... }} breaks on quotes/backticks/HTML in the body and is a
+        # shell script-injection vector.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
-          if echo "$PR_BODY" | grep -q "> REQUIRED:"; then
-            echo "missing_justification=true" >> $GITHUB_OUTPUT
+          if printf '%s' "$PR_BODY" | grep -q "> REQUIRED:"; then
+            echo "missing_justification=true" >> "$GITHUB_OUTPUT"
           else
-            echo "missing_justification=false" >> $GITHUB_OUTPUT
+            echo "missing_justification=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post Nudge Comment

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Every autonomous operation is governed by the same constitutional loop:
 ```mermaid
 flowchart TD
     A["🟢 GOAL\nHUMAN INTENT"] --> B["📂 CONTEXT\nRepo state • knowledge • history"]
-    B --> C["🔒 CONSTRAINTS\nImmutable rules\n209 rules • 13 engines"]
+    B --> C["🔒 CONSTRAINTS\nImmutable rules\n212 rules • 14 engines"]
     C --> D["🗺️ PLAN\nStep-by-step reasoning\nRule-aware plan"]
     D --> E["✨ GENERATE\nCode • changes • tool calls"]
     E --> F["✅ VALIDATE\nDeterministic checks\nAST • semantic • intent • style"]
@@ -228,7 +228,7 @@ Enforcement strengths: **Blocking** · **Reporting** · **Advisory**
 
 Deterministic when possible. LLM only when necessary.
 
-209 rules across 49 rule documents. 204 are mapped to enforcement engines; 5 test-quality rules are still pending mappings. "Mapped" means engine-bound — not enforced in every mode: stateless CI skips `knowledge_gate` and `llm_gate`, which need the knowledge graph and an LLM provider.
+212 rules across 49 rule documents. 207 are mapped to enforcement engines; 5 test-quality rules are still pending mappings. "Mapped" means engine-bound — not enforced in every mode: stateless CI skips `knowledge_gate` and `llm_gate`, which need the knowledge graph and an LLM provider.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -13,7 +13,7 @@ Every autonomous operation in CORE follows the same governed loop:
 ```mermaid
 flowchart TD
     A["🟢 GOAL\nHUMAN INTENT"] --> B["📂 CONTEXT\nRepo state • knowledge • history"]
-    B --> C["🔒 CONSTRAINTS\nImmutable rules\n209 rules • 13 engines"]
+    B --> C["🔒 CONSTRAINTS\nImmutable rules\n212 rules • 14 engines"]
     C --> D["🗺️ PLAN\nStep-by-step reasoning\nRule-aware plan"]
     D --> E["✨ GENERATE\nCode • changes • tool calls"]
     E --> F["✅ VALIDATE\nDeterministic checks\nAST • semantic • intent • style"]

--- a/src/cli/resources/intent/sync_vocabulary.py
+++ b/src/cli/resources/intent/sync_vocabulary.py
@@ -254,7 +254,7 @@ def _build_projection(
     summary="Regenerate a .intent/ projection from its source paper (ADR-023).",
     dangerous=True,
 )
-@core_command(requires_context=True, dangerous=True)
+@core_command(requires_context=True, dangerous=True, requires_brain_services=False)
 # ID: a1f4e8c2-3b7d-4f9e-a2c1-8d6b5e3a4f0c
 async def sync_intent(
     ctx: typer.Context,

--- a/src/cli/utils/decorators.py
+++ b/src/cli/utils/decorators.py
@@ -51,6 +51,7 @@ def core_command(
     confirmation: bool = False,
     requires_context: bool = True,
     offline_capable: bool = False,
+    requires_brain_services: bool = True,
 ):
     """
     Primary constitutional wrapper for CORE CLI commands.
@@ -62,6 +63,16 @@ def core_command(
     `auditor_context` — those services connect to PostgreSQL/Qdrant on
     construction and would crash for a pip-installed runtime that has no
     DB available. See #544.
+
+    `requires_brain_services=False` declares that a command is *inherently*
+    stateless — it never reads `qdrant_service` / `cognitive_service` /
+    `auditor_context` (e.g. file-only projections like `intent sync
+    vocabulary` or `check`-style verifiers). Unlike `offline_capable`, which
+    is gated on a runtime `--offline` flag, this unconditionally skips the
+    eager warm-up: warming Qdrant raises when `QDRANT_URL` is unset, and
+    warming the cognitive service opens a DB session that hangs when the DB
+    is unreachable — neither of which such a command should ever incur. This
+    lets these commands run in a stateless CI runner with no DB/Qdrant.
     """
 
     # ID: e5c51712-e73d-44d2-97a9-82b48817646d
@@ -125,6 +136,7 @@ def core_command(
                 try:
                     if (
                         not offline_run
+                        and requires_brain_services
                         and ctx
                         and ctx.obj
                         and hasattr(ctx.obj, "registry")

--- a/tests/shared/test_cli_utils__core_command.py
+++ b/tests/shared/test_cli_utils__core_command.py
@@ -254,6 +254,51 @@ def test_core_command_with_context_object():
     assert mock_core_context.auditor_context is None
 
 
+def test_core_command_skips_brain_services_when_not_required():
+    """``requires_brain_services=False`` must NOT eagerly resolve
+    qdrant/cognitive/auditor. An inherently stateless command (e.g.
+    ``intent sync vocabulary``) runs in a CI runner with no DB/Qdrant, where
+    warming Qdrant raises (``QDRANT_URL`` unset) and warming the cognitive
+    service opens a DB session that hangs when the DB is unreachable. The
+    warm-up block must be skipped entirely, leaving the three attrs None."""
+    mock_ctx = Mock(spec=typer.Context)
+    mock_core_context = Mock()
+    mock_core_context.registry = Mock()
+    mock_core_context.qdrant_service = None
+    mock_core_context.cognitive_service = None
+    mock_core_context.auditor_context = None
+    mock_ctx.obj = mock_core_context
+
+    # Getters that would blow up if the warm-up path touched them.
+    mock_core_context.registry.get_qdrant_service = AsyncMock(
+        side_effect=ValueError("QDRANT_URL is not configured")
+    )
+    mock_core_context.registry.get_cognitive_service = AsyncMock(
+        side_effect=AssertionError("cognitive warm-up must be skipped")
+    )
+    mock_core_context.registry.get_auditor_context = AsyncMock(
+        side_effect=AssertionError("auditor warm-up must be skipped")
+    )
+
+    captured: dict[str, object] = {}
+
+    @core_command(requires_context=True, requires_brain_services=False)
+    async def stateless_func(ctx: typer.Context):
+        captured["qdrant"] = ctx.obj.qdrant_service
+        captured["cognitive"] = ctx.obj.cognitive_service
+        captured["auditor"] = ctx.obj.auditor_context
+
+    # Must not raise despite the raising getters — warm-up is skipped entirely.
+    stateless_func(mock_ctx)
+
+    assert captured["qdrant"] is None
+    assert captured["cognitive"] is None
+    assert captured["auditor"] is None
+    mock_core_context.registry.get_qdrant_service.assert_not_called()
+    mock_core_context.registry.get_cognitive_service.assert_not_called()
+    mock_core_context.registry.get_auditor_context.assert_not_called()
+
+
 def test_core_command_preserves_function_metadata():
     """Test that core_command preserves the wrapped function's metadata."""
 


### PR DESCRIPTION
## Intent & Justification

Three independent, pre-existing failures in the **CORE CI** workflow — none introduced by recent work. Surfaced while getting the smoke suite green (#681 / #675).

### 1. README count drift (#631)
`README.md` + `docs/how-it-works.md` advertised **209 rules / 204 mapped / 13 engines**; source now has **212 / 207 / 14**. Re-synced so `scripts/check_readme_counts.sh` passes (verified locally: all 7 claims `ok`).

### 2. PR Linter shell-injection
The body check assigned `PR_BODY="${{ github.event.pull_request.body }}"` inline — breaks on quotes/backticks/HTML in the body **and** is a script-injection vector. Now passed via `env:` and read with `printf '%s'`.

### 3. Stateless-command brain-service warm-up
`@core_command` eagerly warms `qdrant_service` / `cognitive_service` / `auditor_context` for every non-offline command. For a file-only command like `intent sync vocabulary --check`, that warm-up **hard-fails when `QDRANT_URL` is unset** (and would hang opening a DB session when the DB is unreachable). Added `requires_brain_services=False` (default `True`, preserving all existing behavior) to declare inherently-stateless commands and skip the warm-up; marked the vocabulary sync command. Extends the #544 offline pattern. Covered by a new two-sided test.

## Scope note
This does **not** fully green the Validate job. Two further blockers remain, which are a separate infra-vs-scope decision:
- `check lint` is a thin client over a core-api server absent in stateless CI.
- `pytest --cov-fail-under=45` may drop below threshold now that DB-backed tests skip when the DB is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)